### PR TITLE
don't set owner of client.json to sensu

### DIFF
--- a/providers/client.rb
+++ b/providers/client.rb
@@ -36,7 +36,6 @@ action :create do
 
   f = sensu_json_file ::File.join(node["sensu"]["directory"], "conf.d", "client.json") do
     content definition
-    owner node["sensu"]["user"]
   end
 
   new_resource.updated_by_last_action(f.updated_by_last_action?)


### PR DESCRIPTION
Causes flapping owners of `/etc/sensu/conf.d`